### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.lucee</groupId>
   <artifactId>log4j-core</artifactId>
-  <version>2.17.0</version>
+  <version>2.17.1</version>
   <name>log4j-core</name>
   <packaging>bundle</packaging>
 
@@ -95,7 +95,7 @@
                  <artifactItem>
                    <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <version>2.17.0</version>
+                    <version>2.17.1</version>
                    <type>jar</type>
                    <overWrite>false</overWrite>
                    <outputDirectory>${project.build.directory}/classes</outputDirectory>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832